### PR TITLE
Fix export links

### DIFF
--- a/src/Config/Permissions/fitting.permissions.php
+++ b/src/Config/Permissions/fitting.permissions.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * User: Warlof Tutsimo <loic.leuilliot@gmail.com>
  * Date: 15/06/2016

--- a/src/Config/fitting.config.php
+++ b/src/Config/fitting.config.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * User: Denngarr B'tarn <denngarr@cripplecreekcorp.com>
  * Date: 2017/11/03.

--- a/src/Models/Fitting.php
+++ b/src/Models/Fitting.php
@@ -293,7 +293,7 @@ class Fitting extends Model
                 continue;
             }
 
-            //Split away to makek sure we only have the main item first.
+            // Split away to makek sure we only have the main item first.
             $mod = explode(',', $line);
             $modu = explode(' x', $mod[0]);
             $module = InvType::where('typeName', $modu[0])->first();

--- a/src/resources/assets/js/fitting.js
+++ b/src/resources/assets/js/fitting.js
@@ -5,6 +5,12 @@ function fillFittingWindow(result) {
         $('#showeft').val(result.eft);
         $('#eftexport').show();
 
+        const exportLinks = $('#exportLinks')
+        exportLinks.show().empty();
+        for(const link of result.exportLinks){
+            exportLinks.append(`<a href="${link.url}" class="list-group-item list-group-item-action">${link.name}</a>`)
+        }
+
         const eveTechUrl = 'https://images.evetech.net/types';
 
         for (const slotType in result) {


### PR DESCRIPTION
In https://github.com/eveseat-plugins/seat-fitting/commit/903d783aec94f75b8d9193d377bb1c9918d4796b, parts of the export link functionality got accidentally dropped. This PR fixes this.

For some reason, your github bot really wants to do some random formatting changes. Sorry for cluttering the PR with them.