### PR TITLE
Doctrine Reports: Allow multiple alliances/corporations at once

### DIFF
--- a/src/Http/Controllers/FittingController.php
+++ b/src/Http/Controllers/FittingController.php
@@ -467,11 +467,11 @@ class FittingController extends Controller implements CalculateConstants
         $doctrine_id = $request->doctrine;
 
         $characters = CharacterInfo::with('skills')->whereHas('affiliation', function ($affiliation) use ($corporation_ids, $alliance_ids) {
-            if(count($alliance_ids)>0) {
+            if (count($alliance_ids) > 0) {
                 $affiliation
                     ->whereIn('alliance_id', $alliance_ids);
             }
-            if(count($corporation_ids)>0) {
+            if (count($corporation_ids) > 0) {
                 $affiliation
                     ->whereIn('corporation_id', $corporation_ids);
             }

--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -126,7 +126,7 @@ Route::group([
             'uses' => 'FittingController@viewDoctrineReport',
             'middleware' => 'can:fitting.reportview',
         ]);
-        Route::get('/runReport/{allianceid}/{corpid}/{doctrineid}', [
+        Route::post('/runReport', [
             'as' => 'cryptafitting::runreport',
             'uses' => 'FittingController@runReport',
             'middleware' => 'can:fitting.reportview',


### PR DESCRIPTION
This PR allows users to select multiple corporations/alliances at the same time when generating a doctrine report. This can be useful to when you have a main corp and a non-wardecable, out-of-alliance corp.
<img width="748" height="353" alt="Bildschirmfoto 2025-07-12 um 15 10 12" src="https://github.com/user-attachments/assets/2822d341-66d4-4ee2-8b25-7be11f23534a" />
